### PR TITLE
ENH: improve reading perfs for dmp files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt_idefix
-version = 0.3.1
+version = 0.3.2
 description = An extension module for yt, adding a frontend for Idefix
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/yt_idefix/__init__.py
+++ b/yt_idefix/__init__.py
@@ -2,4 +2,4 @@ from .data_structures import IdefixDmpDataset, IdefixGrid, IdefixHierarchy
 from .fields import IdefixFieldInfo
 from .io import IdefixIOHandler
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
got a ~25% speedup for a ProjectionPlot example using a 660MiB dataset.
Only problem is that the reshaping is currently broken so the results are incorrect.
fix #17 