### PR TITLE
MNT: drop support for Python 3.6

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install build dependencies
         run: python -m pip install build wheel
       - name: Build distributions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v2.26.0
     hooks:
     - id: pyupgrade
-      args: [--py36-plus]
+      args: [--py37-plus]
 -   repo: https://github.com/psf/black
     rev: 21.8b0
     hooks:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This frontend is a candidate for integration in the core yt code base.
 
 ## Installation
 
-Make sure you have Python 3.6 or newer, then run
+Make sure you have Python 3.7 or newer, then run
 ```shell
 python3 -m pip install yt_idefix
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,13 @@ requires = [
   # https://github.com/numpy/numpy/releases/tag/v1.19.2
   # Cython 3.0 is the next version after 0.29, and a major change,
   # we forbid it until we can properly test against it
-  "Cython>=0.26.1,<3.0; python_version=='3.6'",
-  "Cython>=0.29.21,<3.0; python_version>='3.7'",
+  "Cython>=0.29.21,<3.0",
   "oldest-supported-numpy",
 ]
 
 [tool.black]
 line-length = 88
 target-version = [
-  'py36',
   'py37',
   'py38',
   'py39',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt_idefix
-version = 0.3.2
+version = 0.4.0
 description = An extension module for yt, adding a frontend for Idefix
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -19,7 +19,6 @@ classifiers =
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,7 +37,7 @@ packages = find:
 install_requires =
     inifix>=0.4.6,<1.0
     yt[test]>=4.0.1,<5.0
-python_requires = >=3.6
+python_requires = >=3.7
 test =
     pytest>=6.1
 

--- a/yt_idefix/__init__.py
+++ b/yt_idefix/__init__.py
@@ -2,4 +2,4 @@ from .data_structures import IdefixDmpDataset, IdefixGrid, IdefixHierarchy
 from .fields import IdefixFieldInfo
 from .io import IdefixIOHandler
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"

--- a/yt_idefix/_io/dmp_io.py
+++ b/yt_idefix/_io/dmp_io.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import re
 import struct
 from enum import IntEnum
-from typing import BinaryIO, Dict, List, Optional, Tuple
+from typing import BinaryIO
 
 import numpy as np
 
@@ -46,12 +48,12 @@ def read_next_field_properties(fh: BinaryIO):
 def read_chunk(
     fh: BinaryIO,
     ndim: int,
-    dim: List[int],
+    dim: list[int],
     dtype: str,
     *,
     is_scalar: bool = False,
     skip_data: bool = False,
-) -> Optional[np.ndarray]:
+) -> np.ndarray | None:
     # NOTE: ret type is only dependent on skip_data...
     # this could be better expressed in the type annotationation but it would make
     # more sense to just refactor this function to avoid the boolean trap, so I'll keep wonky
@@ -75,16 +77,16 @@ def read_chunk(
 
 
 def read_serial(
-    fh: BinaryIO, ndim: int, dim: List[int], dtype: str, *, is_scalar: bool = False
-) -> Optional[np.ndarray]:
+    fh: BinaryIO, ndim: int, dim: list[int], dtype: str, *, is_scalar: bool = False
+) -> np.ndarray | None:
     """Emulate Idefix's OutputDump::ReadSerial"""
     assert ndim == 1  # corresponds to an error raised in IDEFIX
     return read_chunk(fh, ndim=ndim, dim=dim, dtype=dtype, is_scalar=is_scalar)
 
 
 def read_distributed(
-    fh: BinaryIO, dim: List[int], *, skip_data: bool = False
-) -> Optional[np.ndarray]:
+    fh: BinaryIO, dim: list[int], *, skip_data: bool = False
+) -> np.ndarray | None:
     """Emulate Idefix's OutputDump::ReadDistributed"""
     # note: OutputDump::ReadDistributed only read doubles
     # because chucks written in integers are small enough
@@ -102,7 +104,7 @@ def read_header(filename: str) -> str:
     return header
 
 
-def get_field_offset_index(fh: BinaryIO) -> Dict[str, int]:
+def get_field_offset_index(fh: BinaryIO) -> dict[str, int]:
     """
     Go over a dumpfile, parse bytes offsets associated with each field.
     Returns
@@ -143,14 +145,14 @@ def read_single_field(fh: BinaryIO, field_offset: int) -> np.ndarray:
 
 def read_idefix_dmpfile(
     filename: str, skip_data: bool = False
-) -> Tuple[IdefixFieldProperties, IdefixMetadata]:
+) -> tuple[IdefixFieldProperties, IdefixMetadata]:
     with open(filename, "rb") as fh:
         return read_idefix_dump_from_buffer(fh, skip_data)
 
 
 def read_idefix_dump_from_buffer(
     fh: BinaryIO, skip_data: bool = False
-) -> Tuple[IdefixFieldProperties, IdefixMetadata]:
+) -> tuple[IdefixFieldProperties, IdefixMetadata]:
 
     # skip header
     fh.seek(CharCount.HEADER * ByteSize.CHAR)

--- a/yt_idefix/_io/vtk_io.py
+++ b/yt_idefix/_io/vtk_io.py
@@ -1,4 +1,6 @@
-from typing import BinaryIO, Dict
+from __future__ import annotations
+
+from typing import BinaryIO
 
 
 def read_header(filename: str) -> str:
@@ -6,5 +8,5 @@ def read_header(filename: str) -> str:
         return "".join(fh.readline(256).decode() for _ in range(2))
 
 
-def get_field_offset_index(fh: BinaryIO) -> Dict[str, int]:  # type: ignore
+def get_field_offset_index(fh: BinaryIO) -> dict[str, int]:  # type: ignore
     ...

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import os
 import re
 import warnings
 import weakref
 from abc import ABC, abstractmethod
-from typing import BinaryIO, Dict, List, Tuple
+from typing import BinaryIO
 
 import inifix
 import numpy as np
@@ -87,19 +89,19 @@ class IdefixHierarchy(GridIndex, ABC):
 
     @staticmethod
     @abstractmethod
-    def _get_field_offset_index(fh: BinaryIO) -> Dict[str, int]:
+    def _get_field_offset_index(fh: BinaryIO) -> dict[str, int]:
         pass
 
 
 class IdefixVtkHierarchy(IdefixHierarchy):
     @staticmethod
-    def _get_field_offset_index(fh: BinaryIO) -> Dict[str, int]:
+    def _get_field_offset_index(fh: BinaryIO) -> dict[str, int]:
         return vtk_io.get_field_offset_index(fh)
 
 
 class IdefixDmpHierarchy(IdefixHierarchy):
     @staticmethod
-    def _get_field_offset_index(fh: BinaryIO) -> Dict[str, int]:
+    def _get_field_offset_index(fh: BinaryIO) -> dict[str, int]:
         return dmp_io.get_field_offset_index(fh)
 
 
@@ -176,7 +178,7 @@ class IdefixDataset(Dataset, ABC):
         self.parameters.update(inifix.load(self.inifile))
         grid_ini = self.parameters["Grid"]
 
-        msg_elems: List[str] = []
+        msg_elems: list[str] = []
         for ax, vals in grid_ini.items():
             if vals[0] > 1:
                 # more than one block is only relevant for mixing grid spacings,
@@ -213,7 +215,7 @@ class IdefixDataset(Dataset, ABC):
             setdefaultattr(self, key, self.quan(1, unit))
 
     @abstractmethod
-    def _get_fields_metadata(self) -> Tuple[IdefixFieldProperties, IdefixMetadata]:
+    def _get_fields_metadata(self) -> tuple[IdefixFieldProperties, IdefixMetadata]:
         pass
 
     @abstractmethod
@@ -250,7 +252,7 @@ class IdefixDmpDataset(IdefixDataset):
             ok = False
         return ok
 
-    def _get_fields_metadata(self) -> Tuple[IdefixFieldProperties, IdefixMetadata]:
+    def _get_fields_metadata(self) -> tuple[IdefixFieldProperties, IdefixMetadata]:
         # read everything except large arrays
         return dmp_io.read_idefix_dmpfile(self.parameter_filename, skip_data=True)
 


### PR DESCRIPTION
motivation: unlock dataclasses