### PR TITLE
DEPR: deprecate yt_idefix.load, update requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         ]
         python-version: [
           '3.8',
-          '3.9',
+          '3.10',
         ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: v1.20.0
     hooks:
     -   id: setup-cfg-fmt
-        args: [--max-py-version, '3.9']
+        args: [--max-py-version, '3.10']
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # yt_idefix
 [![PyPI](https://img.shields.io/pypi/v/yt-idefix.svg?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/yt_idefix/)
-[![PyPI](https://img.shields.io/pypi/pyversions/yt-idefix/0.8.0?logo=python&logoColor=white&label=Python)](https://pypi.org/project/yt_idefix/)
+[![PyPI](https://img.shields.io/pypi/pyversions/yt-idefix/0.11.0?logo=python&logoColor=white&label=Python)](https://pypi.org/project/yt_idefix/)
 [![yt-project](https://img.shields.io/static/v1?label="works%20with"&message="yt"&color="blueviolet")](https://yt-project.org)
 
 <!--- Tests and style --->
@@ -10,10 +10,8 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 
-A maturing yt frontend for Idefix, packaged as an extension for yt.
+A maturing yt frontend for Idefix and Pluto (vtk), packaged as an extension for yt.
 This frontend is a candidate for integration in the core yt code base.
-
-Starting from version 0.8.0, Pluto vtk files are also supported by this frontend.
 
 ## Installation
 
@@ -27,22 +25,13 @@ After importing `yt` itself, make sure to activate the extension
 import yt
 import yt_idefix
 ```
-Single dump files as well as time series can be loaded directly with `yt.load`, e.g.,
-```python
-ds = yt.load("dump.0054.dmp")
-ts = yt.load("dump.00??.dmp")
-```
 
-For vtk files, with yt < 4.0.2, a specialized loader function is provided
-```python
-ds = yt_idefix.load("data.0042.vtk")
-```
-With yt >= 4.0.2 (not released yet), this workaround will not be necessary and `yt.load` will be usable directly.
+Now `yt.load` will be able to read Pluto/Idefix `.vtk` output files, as well as Idefix `.dmp` dump files.
 
 
 ### Strecthed grids support
 
-yt_idefix comes a specialized loader function for datasets with streched grids
+yt_idefix ships a specialized loader function for datasets with streched grids
 `yt_idefix.load_stretched`. This function is experimental. Here are its known
 limitations.
 - no field magic (no aliasing, or dimensionalization, or automatic derived field generation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ line-length = 88
 target-version = [
   'py38',
   'py39',
+  'py310'
 ]
 include = '\.pyi?$'
 exclude = '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt_idefix
-version = 0.11.0dev
+version = 0.11.0
 description = An extension module for yt, adding a frontend for Idefix
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
     Topic :: Scientific/Engineering :: Visualization
@@ -36,7 +37,7 @@ project_urls =
 packages = find:
 install_requires =
     inifix>=1.0.2
-    yt[test]>=4.0.1
+    yt[test]>=4.0.2
 python_requires = >=3.8
 
 [options.extras_require]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,24 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
 import unyt as un
 import yaml
+
+
+def pytest_configure(config):
+    if sys.version_info >= (3, 10):
+        # from numpy, still visible in 1.22.x
+        config.addinivalue_line(
+            "filterwarnings",
+            (
+                "ignore:The distutils.sysconfig module is deprecated, use sysconfig instead:DeprecationWarning"
+            ),
+        )
 
 
 def parse_quantity(s) -> un.unyt_quantity:

--- a/tests/test_vtk.py
+++ b/tests/test_vtk.py
@@ -36,7 +36,7 @@ def test_class_validation(vtk_file):
 
 def test_parse_pluto_metadata(pluto_vtk_file):
     file = pluto_vtk_file
-    ds = yt_idefix.load(file["path"])
+    ds = yt.load(file["path"])
     assert os.path.samefile(
         ds._definitions_header, file["path"].parent / "definitions.h"
     )
@@ -52,7 +52,7 @@ def test_parse_pluto_metadata(pluto_vtk_file):
 
 def test_pluto_units(pluto_vtk_file):
     file = pluto_vtk_file
-    ds = yt_idefix.load(file["path"])
+    ds = yt.load(file["path"])
     for u, expected in file["units"].items():
         assert_allclose_units(getattr(ds, f"{u}_unit"), expected)
 
@@ -66,7 +66,7 @@ def test_pluto_complete_units_override(pluto_vtk_file):
             uo[unit] = su[unit]
         if set(uo) in PlutoVtkDataset.invalid_unit_combinations:
             continue
-        ds = yt_idefix.load(
+        ds = yt.load(
             pluto_vtk_file["path"],
             geometry=pluto_vtk_file["geometry"],
             units_override=uo,
@@ -79,7 +79,7 @@ def test_pluto_one_unit_override(pluto_vtk_file):
     file = pluto_vtk_file
     # Pluto's length_unit and density_unit will be combined with
     uo = {"time_unit": (2.0, "yr")}
-    ds = yt_idefix.load(file["path"], geometry=file["geometry"], units_override=uo)
+    ds = yt.load(file["path"], geometry=file["geometry"], units_override=uo)
     # Pluto's length_unit should be preserved
     assert_allclose_units(ds.length_unit, file["units"]["length"])
     # Pluto's velocity_unit should be overrided
@@ -91,7 +91,7 @@ def test_pluto_two_units_override(pluto_vtk_file):
     file = pluto_vtk_file
     # Pluto's length_unit will be combined with
     uo = {"time_unit": (2.0, "yr"), "density_unit": (32.0, "g/cm**3")}
-    ds = yt_idefix.load(file["path"], geometry=file["geometry"], units_override=uo)
+    ds = yt.load(file["path"], geometry=file["geometry"], units_override=uo)
     # Pluto's length_unit should be preserved
     assert_allclose_units(ds.length_unit, file["units"]["length"])
     # Pluto's velocity_unit should be overrided
@@ -104,7 +104,7 @@ def test_pluto_two_units_override(pluto_vtk_file):
 def test_pluto_invalid_units_override(pluto_vtk_file):
     for uo in PlutoVtkDataset.invalid_unit_combinations:
         with pytest.raises(ValueError, match=r".* cannot derive all units\n.*"):
-            yt_idefix.load(
+            yt.load(
                 pluto_vtk_file["path"],
                 geometry=pluto_vtk_file["geometry"],
                 units_override=uo,
@@ -119,7 +119,7 @@ def test_pluto_temperature_unit_override(pluto_vtk_file):
             "since it's always in Kelvin in PLUTO"
         ),
     ):
-        yt_idefix.load(
+        yt.load(
             pluto_vtk_file["path"],
             geometry=pluto_vtk_file["geometry"],
             units_override={"temperature_unit": (2.0, "K")},
@@ -136,7 +136,7 @@ def test_pluto_over_units_override(pluto_vtk_file):
             )
         ),
     ):
-        yt_idefix.load(
+        yt.load(
             pluto_vtk_file["path"],
             geometry=pluto_vtk_file["geometry"],
             units_override=SAMPLE_UNITS,
@@ -151,7 +151,7 @@ def test_pluto_wrong_definitions_header(pluto_vtk_file):
             "The 'geometry' keyword argument must be specified."
         ),
     ):
-        yt_idefix.load(pluto_vtk_file["path"], definitions_header="definitions2.h")
+        yt.load(pluto_vtk_file["path"], definitions_header="definitions2.h")
 
 
 def test_pluto_wrong_definitions_header_with_geometry(pluto_vtk_file):
@@ -162,7 +162,7 @@ def test_pluto_wrong_definitions_header_with_geometry(pluto_vtk_file):
             "The code units are set to be 1.0 in cgs by default."
         ),
     ):
-        yt_idefix.load(
+        yt.load(
             pluto_vtk_file["path"],
             definitions_header="definitions2.h",
             geometry="cartesian",
@@ -171,14 +171,14 @@ def test_pluto_wrong_definitions_header_with_geometry(pluto_vtk_file):
 
 def test_data_access(vtk_file):
     file = vtk_file
-    ds = yt_idefix.load(file["path"], geometry=file["geometry"])
+    ds = yt.load(file["path"], geometry=file["geometry"])
     ad = ds.all_data()
     ad["gas", "density"]
 
 
 def test_load_user_passed_geometry(vtk_file):
     file = vtk_file
-    ds = yt_idefix.load(file["path"], geometry=file["geometry"])
+    ds = yt.load(file["path"], geometry=file["geometry"])
     assert ds.geometry == file["geometry"]
     assert ds.dimensionality == file["dimensionality"]
 
@@ -191,18 +191,18 @@ def test_load_missing_geometry_metadata(vtk_file_no_geom):
             "The 'geometry' keyword argument must be specified."
         ),
     ):
-        yt_idefix.load(vtk_file_no_geom["path"])
+        yt.load(vtk_file_no_geom["path"])
 
 
 def test_load_parseable_geometry_metadata(vtk_file_with_geom):
     file = vtk_file_with_geom
-    ds = yt_idefix.load(file["path"])
+    ds = yt.load(file["path"])
     assert ds.geometry == file["geometry"]
 
 
 def test_derived_field(vtk_file):
     file = vtk_file
-    ds = yt_idefix.load(file["path"], geometry=file["geometry"])
+    ds = yt.load(file["path"], geometry=file["geometry"])
     # this derived field is compatible for all current test data
     # it'll be replaced once a better universal field is defined internally.
 
@@ -224,24 +224,19 @@ def test_derived_field(vtk_file):
 # TODO: make this a pytest-mpl test
 def test_slice_plot(vtk_file):
     file = vtk_file
-    ds = yt_idefix.load(file["path"], geometry=file["geometry"], unit_system="code")
-    if YT_VERSION <= Version("4.0.1"):
+    ds = yt.load(file["path"], geometry=file["geometry"], unit_system="code")
+    if YT_VERSION <= Version("4.1.dev0"):
         if ds.geometry == "spherical":
             normal = "phi"
         else:
             normal = "z"
         yt.SlicePlot(ds, normal=normal, fields=("gas", "density"))
     else:
-        # this should work but it's broken with yt 4.0.1
+        # this should work but it's broken with yt 4.0.x
         # it is fixed in https://github.com/yt-project/yt/pull/3489
         yt.SlicePlot(ds, normal=(0, 0, 1), fields=("gas", "density"))
 
 
-@pytest.mark.xfail(
-    YT_VERSION < Version("4.0.2"),
-    reason="all .vtk files are detected as Athena-compatible, "
-    "hence dataformat is considered ambiguous before yt 4.0.2",
-)
 def test_load_magic(vtk_file):
     ds = yt.load(vtk_file["path"], geometry=vtk_file["geometry"])
     assert isinstance(ds, IdefixVtkDataset)

--- a/yt_idefix/__init__.py
+++ b/yt_idefix/__init__.py
@@ -2,4 +2,4 @@
 # immediately after `import yt.extensions.idefix`
 from yt_idefix.api import *
 
-__version__ = "0.11.0dev"
+__version__ = "0.11.0"

--- a/yt_idefix/loaders.py
+++ b/yt_idefix/loaders.py
@@ -1,44 +1,30 @@
 from __future__ import annotations
 
-import os
+import warnings
 
 import numpy as np
-from packaging.version import Version
 
 import yt
-from yt.utilities.exceptions import YTUnidentifiedDataType
 from yt_idefix._io import vtk_io
 from yt_idefix.data_structures import IdefixVtkDataset, PlutoVtkDataset
-
-YT_VERSION = Version(yt.__version__)
 
 __all__ = ["load", "load_stretched"]
 
 
-class IdefixVtkDatasetSeries(yt.DatasetSeries):
-    _dataset_cls = IdefixVtkDataset
+class VisibleDeprecationWarning(Warning):
+    pass
 
 
 def load(fn, *args, **kwargs):
-    """
-    drop-in replacement for yt.load with a workaround for vtk files
-    (recognized as Athena format with yt < 4.0.2)
-    """
-    fn = os.path.expanduser(fn)
-    if not os.path.exists(fn):
-        raise FileNotFoundError(fn)
-
-    if YT_VERSION < Version("4.0.2") and fn.endswith(".vtk"):
-        if any(wildcard in fn for wildcard in "[]?!*"):
-            return IdefixVtkDatasetSeries(fn, *args, **kwargs)
-        elif IdefixVtkDataset._is_valid(fn, *args, **kwargs):
-            return IdefixVtkDataset(fn, *args, **kwargs)
-        elif PlutoVtkDataset._is_valid(fn, *args, **kwargs):
-            return PlutoVtkDataset(fn, *args, **kwargs)
-        else:
-            raise YTUnidentifiedDataType(fn, *args, **kwargs)
-    else:
-        return yt.load(fn, *args, **kwargs)
+    warnings.warn(
+        "yt_idefix.load is now a strict alias to yt.load, "
+        "please use yt.load directly. "
+        "yt_idefix.load was deprecated in version 0.11.0 "
+        "and will be removed no later than version 0.13.0",
+        category=VisibleDeprecationWarning,
+        stacklevel=2,
+    )
+    return yt.load(fn, *args, **kwargs)
 
 
 def load_stretched(fn, *, geometry: str | None = None, **kwargs):


### PR DESCRIPTION
Opening as a draft (yt 4.0.2 isn't out yet, so this will fail CI at first)