### PR TITLE
RFC: disantangle metadata parsing for vtk files, centralize geometry validation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt_idefix
-version = 0.11.0
+version = 0.11.1
 description = An extension module for yt, adding a frontend for Idefix
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_vtk.py
+++ b/tests/test_vtk.py
@@ -146,27 +146,9 @@ def test_pluto_over_units_override(pluto_vtk_file):
 def test_pluto_wrong_definitions_header(pluto_vtk_file):
     with pytest.raises(
         FileNotFoundError,
-        match=(
-            "Header file definitions2.h couldn't be found. "
-            "The 'geometry' keyword argument must be specified."
-        ),
+        match=("No such file 'definitions2.h'"),
     ):
         yt.load(pluto_vtk_file["path"], definitions_header="definitions2.h")
-
-
-def test_pluto_wrong_definitions_header_with_geometry(pluto_vtk_file):
-    with pytest.warns(
-        UserWarning,
-        match=(
-            "Header file definitions2.h couldn't be found. "
-            "The code units are set to be 1.0 in cgs by default."
-        ),
-    ):
-        yt.load(
-            pluto_vtk_file["path"],
-            definitions_header="definitions2.h",
-            geometry=pluto_vtk_file["geometry"],
-        )
 
 
 def test_data_access(vtk_file):

--- a/yt_idefix/__init__.py
+++ b/yt_idefix/__init__.py
@@ -2,4 +2,4 @@
 # immediately after `import yt.extensions.idefix`
 from yt_idefix.api import *
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/yt_idefix/_io/commons.py
+++ b/yt_idefix/_io/commons.py
@@ -26,20 +26,26 @@ class Shape(NamedTuple):
 
 
 class Coordinates(NamedTuple):
+    # Store 3 1D coordinates arrays and one 'array_shape'
     x1: np.ndarray
     x2: np.ndarray
     x3: np.ndarray
+    array_shape: Shape  # the 3D shape that 1D arrays should be broadcasted to
 
     @property
     def shape(self) -> Shape:
         return Shape(len(self.x1), len(self.x2), len(self.x3))
 
+    @property
+    def arrays(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        return self.x1, self.x2, self.x3
+
     def padded(self) -> Coordinates:
-        arrs = list(self)
-        for i, arr in enumerate(arrs):
+        arrs = [_.copy() for _ in self.arrays]
+        for i, arr in enumerate(self.arrays):
             if arr.size == 1:
                 arrs[i] = np.array((arr[0], arr[0] + 1))
-        return Coordinates(*arrs)
+        return Coordinates(arrs[0], arrs[1], arrs[2], self.array_shape)
 
 
 # map field name to numpy array init data:

--- a/yt_idefix/_io/dmp_io.py
+++ b/yt_idefix/_io/dmp_io.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 import struct
-import warnings
 from enum import IntEnum
 from typing import BinaryIO, Literal, cast, overload
 
@@ -292,10 +291,7 @@ def read_idefix_dump_from_buffer(
         fdata[field_name] = data
         field_name, dtype, ndim, dim = read_next_field_properties(fh)
 
-    if "geometry" not in fdata:
-        warnings.warn("Could not determine geometry, assuming cartesian.")
-        fdata["geometry"] = "cartesian"
-    elif isinstance(fdata["geometry"], int):
+    if isinstance(fdata["geometry"], int):
         fdata["geometry"] = KNOWN_GEOMETRIES[fdata["geometry"]]
     else:
         raise RuntimeError(

--- a/yt_idefix/loaders.py
+++ b/yt_idefix/loaders.py
@@ -48,10 +48,13 @@ def load_stretched(fn, *, geometry: str | None = None, **kwargs):
 
     # actual parsing
     with open(fn, "rb") as fh:
-        md = vtk_io.read_metadata(fh, geometry=geometry)
-        coords = vtk_io.read_grid_coordinates(fh, md).padded()
-        shape = md["array_shape"]
-        field_offset_index = vtk_io.read_field_offset_index(fh, shape=shape)
+        md = vtk_io.read_metadata(fh)
+        coords = vtk_io.read_grid_coordinates(
+            fh, geometry=geometry or md.get("geometry")
+        ).padded()
+        field_offset_index = vtk_io.read_field_offset_index(
+            fh, shape=coords.array_shape
+        )
 
     if geometry is None:
         geometry = md["geometry"]
@@ -60,7 +63,7 @@ def load_stretched(fn, *, geometry: str | None = None, **kwargs):
     with open(fn, "rb") as fh:
         for name, offset in field_offset_index.items():
             data[name] = vtk_io.read_single_field(
-                fh, shape=shape, offset=offset, skip_data=False
+                fh, shape=coords.array_shape, offset=offset, skip_data=False
             )
 
     coordinates, connectivity = yt.hexahedral_connectivity(


### PR DESCRIPTION
This is supposed to be a simple refactor with no changes but I found that it breaks some PLUTO tests where we call `yt_idefix.load()` without a `geometry` argument, though I think the geometry is _supposed_ to be automatically parsed from `definitions.h`.

@xshaokun, I'd like your feedback on this if you can. I think it's a bug that pre-exists and I'm just making it apparent, can you confirm/infirm ?