### PR TITLE
MNT: reallow compat with yt 4.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt_idefix
-version = 0.11.1
+version = 0.11.2
 description = An extension module for yt, adding a frontend for Idefix
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -37,7 +37,7 @@ project_urls =
 packages = find:
 install_requires =
     inifix>=1.0.2
-    yt[test]>=4.0.2
+    yt[test]>=4.0.1
 python_requires = >=3.8
 
 [options.extras_require]

--- a/yt_idefix/__init__.py
+++ b/yt_idefix/__init__.py
@@ -2,4 +2,4 @@
 # immediately after `import yt.extensions.idefix`
 from yt_idefix.api import *
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"


### PR DESCRIPTION
I now think #86 is really a regression upstream (I probably broke one of yt's pixelizers in between 4.0.1 and 4.0.2), so I'm restoring compatibility with 4.0.1
this should close #86, and I'll need to report/patch this upstream

I don't want to backpedal #73 completely so I won't be _testing_ against yt 4.0.1 anymore, if I can avoid it.