### PR TITLE
BUG: fix incorrect conversion between code_time and cgs_unit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,18 @@ def vtk_file_with_geom(request):
     return request.param
 
 
+VTK_FILES_WITH_UNITS = {k: v for k, v in VTK_FILES.items() if v["has_units"] is True}
+
+
+@pytest.fixture(
+    params=VTK_FILES_WITH_UNITS.values(),
+    ids=VTK_FILES_WITH_UNITS.keys(),
+    scope="session",
+)
+def vtk_file_with_units(request):
+    return request.param
+
+
 IDEFIX_VTK_FILES = {k: v for k, v in VTK_FILES.items() if v["kind"] == "idefix"}
 
 
@@ -136,18 +148,4 @@ PLUTO_VTK_FILES = {k: v for k, v in VTK_FILES.items() if v["kind"] == "pluto"}
     params=PLUTO_VTK_FILES.values(), ids=PLUTO_VTK_FILES.keys(), scope="session"
 )
 def pluto_vtk_file(request):
-    return request.param
-
-
-PLUTO_VTK_FILES_DEF_UNITS = {
-    k: v for k, v in PLUTO_VTK_FILES.items() if v["def_units"] is True
-}
-
-
-@pytest.fixture(
-    params=PLUTO_VTK_FILES_DEF_UNITS.values(),
-    ids=PLUTO_VTK_FILES_DEF_UNITS.keys(),
-    scope="session",
-)
-def pluto_vtk_file_def_units(request):
     return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,3 +137,17 @@ PLUTO_VTK_FILES = {k: v for k, v in VTK_FILES.items() if v["kind"] == "pluto"}
 )
 def pluto_vtk_file(request):
     return request.param
+
+
+PLUTO_VTK_FILES_DEF_UNITS = {
+    k: v for k, v in PLUTO_VTK_FILES.items() if v["def_units"] is True
+}
+
+
+@pytest.fixture(
+    params=PLUTO_VTK_FILES_DEF_UNITS.values(),
+    ids=PLUTO_VTK_FILES_DEF_UNITS.keys(),
+    scope="session",
+)
+def pluto_vtk_file_def_units(request):
+    return request.param

--- a/tests/data/FargoMHDSpherical/meta.yaml
+++ b/tests/data/FargoMHDSpherical/meta.yaml
@@ -6,3 +6,4 @@ attrs:
   geometry: spherical
   dimensionality: 3
   kind: idefix
+  has_units: False

--- a/tests/data/cataclysmic-disk/meta.yaml
+++ b/tests/data/cataclysmic-disk/meta.yaml
@@ -7,3 +7,4 @@ attrs:
   geometry: polar
   dimensionality: 2
   kind: idefix
+  has_units: False

--- a/tests/data/khi/meta.yaml
+++ b/tests/data/khi/meta.yaml
@@ -6,3 +6,4 @@ attrs:
   geometry: cartesian
   dimensionality: 2
   kind: idefix
+  has_units: False

--- a/tests/data/pluto_disk_planet/meta.yaml
+++ b/tests/data/pluto_disk_planet/meta.yaml
@@ -5,6 +5,7 @@ attrs:
   geometry: spherical
   dimensionality: 3
   kind: pluto
+  def_units: True
   units:
     length: "7.77909038e13 cm"
     velocity: "208457.8557 cm/s"

--- a/tests/data/pluto_disk_planet/meta.yaml
+++ b/tests/data/pluto_disk_planet/meta.yaml
@@ -5,7 +5,7 @@ attrs:
   geometry: spherical
   dimensionality: 3
   kind: pluto
-  def_units: True
+  has_units: True
   units:
     length: "7.77909038e13 cm"
     velocity: "208457.8557 cm/s"

--- a/tests/data/pluto_rotor/meta.yaml
+++ b/tests/data/pluto_rotor/meta.yaml
@@ -5,6 +5,7 @@ attrs:
   geometry: polar
   dimensionality: 2
   kind: pluto
+  def_units: False
   units:
     length: "1.0 cm"
     velocity: "1.0 cm/s"

--- a/tests/data/pluto_rotor/meta.yaml
+++ b/tests/data/pluto_rotor/meta.yaml
@@ -5,7 +5,7 @@ attrs:
   geometry: polar
   dimensionality: 2
   kind: pluto
-  def_units: False
+  has_units: False
   units:
     length: "1.0 cm"
     velocity: "1.0 cm/s"

--- a/tests/data/pluto_sedov/meta.yaml
+++ b/tests/data/pluto_sedov/meta.yaml
@@ -5,7 +5,7 @@ attrs:
   geometry: cartesian
   dimensionality: 3
   kind: pluto
-  def_units: True
+  has_units: True
   units:
     length: "3.08567758e21 cm"
     velocity: "1e5 cm/s"

--- a/tests/data/pluto_sedov/meta.yaml
+++ b/tests/data/pluto_sedov/meta.yaml
@@ -5,6 +5,7 @@ attrs:
   geometry: cartesian
   dimensionality: 3
   kind: pluto
+  def_units: True
   units:
     length: "3.08567758e21 cm"
     velocity: "1e5 cm/s"

--- a/tests/data/pluto_sod/meta.yaml
+++ b/tests/data/pluto_sod/meta.yaml
@@ -6,6 +6,7 @@ attrs:
   dimensionality: 1
   kind: pluto
   current_time: null
+  def_units: False
   units:
     length: "1.0 cm"
     velocity: "1.0 cm/s"

--- a/tests/data/pluto_sod/meta.yaml
+++ b/tests/data/pluto_sod/meta.yaml
@@ -6,7 +6,7 @@ attrs:
   dimensionality: 1
   kind: pluto
   current_time: null
-  def_units: False
+  has_units: False
   units:
     length: "1.0 cm"
     velocity: "1.0 cm/s"

--- a/tests/test_vtk.py
+++ b/tests/test_vtk.py
@@ -151,8 +151,8 @@ def test_pluto_wrong_definitions_header(pluto_vtk_file):
         yt.load(pluto_vtk_file["path"], definitions_header="definitions2.h")
 
 
-def test_pluto_code_time(pluto_vtk_file_def_units):
-    ds = yt.load(pluto_vtk_file_def_units["path"])
+def test_code_time(vtk_file_with_units):
+    ds = yt.load(vtk_file_with_units["path"])
     code_time = Unit("code_time", registry=ds.unit_registry)
     assert_allclose_units(ds.time_unit, 1.0 * code_time)
     assert_allclose_units(ds.current_time.in_cgs(), ds.current_time.value * code_time)

--- a/tests/test_vtk.py
+++ b/tests/test_vtk.py
@@ -4,7 +4,7 @@ import re
 import pytest
 from more_itertools import distinct_combinations
 from packaging.version import Version
-from unyt import assert_allclose_units
+from unyt import Unit, assert_allclose_units
 
 import yt
 import yt_idefix
@@ -149,6 +149,15 @@ def test_pluto_wrong_definitions_header(pluto_vtk_file):
         match=("No such file 'definitions2.h'"),
     ):
         yt.load(pluto_vtk_file["path"], definitions_header="definitions2.h")
+
+
+def test_pluto_code_time(pluto_vtk_file_def_units):
+    ds = yt.load(pluto_vtk_file_def_units["path"])
+    code_time = Unit("code_time", registry=ds.unit_registry)
+    assert_allclose_units(ds.time_unit, 1.0 * code_time)
+    assert_allclose_units(ds.current_time.in_cgs(), ds.current_time.value * code_time)
+    quantity = ds.quan(1.0, "code_time")
+    assert_allclose_units(quantity.in_cgs(), quantity.value * code_time)
 
 
 def test_data_access(vtk_file):

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -293,7 +293,7 @@ class IdefixVtkDataset(IdefixDataset):
         self.domain_right_edge = dre
 
         # time wasn't stored in vtk files before Idefix 0.8
-        self.current_time = self.quan(md.get("time", -1), "code_time")
+        self.current_time = md.get("time", -1)
 
         # periodicity was not stored in vtk files before Idefix 0.9
         self._periodicity = md.get("periodicity", (True, True, True))
@@ -344,7 +344,7 @@ class IdefixDmpDataset(IdefixDataset):
             [fdata[f"xr{idir}"][-1] for idir in "123"], dtype="float64"
         )
 
-        self.current_time = self.quan(fdata["time"], "code_time")
+        self.current_time = fdata["time"]
 
         self._periodicity = tuple(bool(p) for p in fdata["periodicity"])
 
@@ -441,16 +441,15 @@ class PlutoVtkDataset(IdefixVtkDataset):
             )
         index = int(match.group(1))
 
-        self.current_time = self.quan(-1, "code_time")
+        # will be converted to actual unyt_quantity in _set_derived_attrs
+        self.current_time = -1
         if os.path.isfile(log_file):
             log_regexp = re.compile(rf"^{index}\s(\S+)")
             with open(log_file) as fh:
                 for line in fh.readlines():
                     log_match = re.search(log_regexp, line)
                     if log_match:
-                        self.current_time = self.quan(
-                            float(log_match.group(1)), "code_time"
-                        )
+                        self.current_time = float(log_match.group(1))
                         break
                 else:
                     ytLogger.warning(
@@ -459,18 +458,6 @@ class PlutoVtkDataset(IdefixVtkDataset):
                     )
         else:
             ytLogger.warning("Missing log file %s, setting current_time = -1", log_file)
-
-    def set_code_units(self):
-        super().set_code_units()
-        # Here we need to clean the unit cache
-        # to remove any cached code units with default conversion factor
-        self.unit_registry._unit_object_cache.clear()
-
-    def _set_derived_attrs(self):
-        super()._set_derived_attrs()
-        # Some attrs were initialized with code units but with default conversion factor,
-        # we need to update them after the code units are modified in self.set_code_units()
-        self.current_time = self.quan(self.current_time, "code_time")
 
     def _set_code_unit_attributes(self):
         """Conversion between physical units and code units."""

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -293,7 +293,7 @@ class IdefixVtkDataset(IdefixDataset):
         self.domain_right_edge = dre
 
         # time wasn't stored in vtk files before Idefix 0.8
-        self.current_time = self.quan(md.get("time", -1), "code_time")
+        self.current_time = md.get("time", -1)
 
         # periodicity was not stored in vtk files before Idefix 0.9
         self._periodicity = md.get("periodicity", (True, True, True))
@@ -441,16 +441,14 @@ class PlutoVtkDataset(IdefixVtkDataset):
             )
         index = int(match.group(1))
 
-        self.current_time = self.quan(-1, "code_time")
+        self.current_time = -1
         if os.path.isfile(log_file):
             log_regexp = re.compile(rf"^{index}\s(\S+)")
             with open(log_file) as fh:
                 for line in fh.readlines():
                     log_match = re.search(log_regexp, line)
                     if log_match:
-                        self.current_time = self.quan(
-                            float(log_match.group(1)), "code_time"
-                        )
+                        self.current_time = float(log_match.group(1))
                         break
                 else:
                     ytLogger.warning(


### PR DESCRIPTION
The behavior of this bug can be shown by the following code:
``` Python
ds = yt.load("tests/data/pluto_disk_planet/data.0010.vtk")
print("current_time: ", ds.current_time)
print("current_time_cgs: ", ds.current_time.in_cgs())
print("time_unit: ", ds.time_unit)
codet = ds.quan(1, "code_time")
print("code_time", ds.unit_registry["code_time"])
print("codet: ", codet)
print("codet_cgs: ", codet.in_cgs())
```

The ouput is 
```
current_time:  1.0 code_time
current_time_cgs:  1.0 s
time_unit:  373173289.848891 s
code_time (373173289.848891, (time), 0.0, '\\rm{code\\ time}', False)
codet:  1 code_time
codet_cgs:  1.0 s
```

The reason is our too early calling of "code_time" in the definition of `self.current_time`, which is called before `self.set_units()`. So the conversion factor between code_unit and cgs_time hasn't setup yet. 

While I don't know why the definition of `code_time` is correct but is wrong in `ds.quan()` (see the behavior of `codet`)

In this PR, I just left `self.current_time` to be an int/float object and it is converted to unyt_quantity by `self._set_derived_attrs()` later.