### PR TITLE
BUG: fix an issue where azimuthal coordinates in polar geometry was incorrectly shifted

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt_idefix
-version = 0.11.6
+version = 0.11.7
 description = An extension module for yt, adding a frontend for Idefix
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/yt_idefix/__init__.py
+++ b/yt_idefix/__init__.py
@@ -2,4 +2,4 @@
 # immediately after `import yt.extensions.idefix`
 from yt_idefix.api import *
 
-__version__ = "0.11.6"
+__version__ = "0.11.7"

--- a/yt_idefix/_io/vtk_io.py
+++ b/yt_idefix/_io/vtk_io.py
@@ -199,9 +199,7 @@ def read_grid_coordinates(
             data_type = next(fh).decode().split()[0]  # CELL_DATA (NX-1)(NY-1)(NZ-1)
             next(fh)
 
-            # manually changing phase origin (theta) to match
-            # results from Idefix's pytools
-            coords = [r, theta + np.pi, z]
+            coords = [r, theta, z]
         else:
             assert geometry == "spherical"
             # Reconstruct the spherical coordinate system


### PR DESCRIPTION
Follow up to https://github.com/neutrinoceros/yt_idefix/pull/27
I honestly can't remember why exactly I thought this shift was a good thing, but it's objectively broken (it produces angles outside of the (0, 2 PI) interval).
This was fine up to yt 4.0.2 but the problem surfaced with yt 4.0.3, with which polar plots are uterly broken. This fixes the problem entirely.