### PR TITLE
MNT: bump yt requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ project_urls =
 packages = find:
 install_requires =
     inifix>=2.3.0
-    yt==4.0.3
+    yt==4.0.4
 python_requires = >=3.8
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ project_urls =
 packages = find:
 install_requires =
     inifix>=2.3.0
-    yt>=4.0.1
+    yt==4.0.2
 python_requires = >=3.8
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ project_urls =
 packages = find:
 install_requires =
     inifix>=2.3.0
-    yt==4.0.2
+    yt==4.0.3
 python_requires = >=3.8
 
 [options.extras_require]

--- a/tests/test_vtk.py
+++ b/tests/test_vtk.py
@@ -3,14 +3,11 @@ import re
 
 import pytest
 from more_itertools import distinct_combinations
-from packaging.version import Version
 from unyt import Unit, assert_allclose_units
 
 import yt
 import yt_idefix
 from yt_idefix.api import IdefixVtkDataset, PlutoVtkDataset
-
-YT_VERSION = Version(yt.__version__)
 
 # A sample list of units for test.
 # The first three values are chosen randomly

--- a/tests/test_vtk.py
+++ b/tests/test_vtk.py
@@ -216,16 +216,7 @@ def test_derived_field(vtk_file):
 def test_slice_plot(vtk_file):
     file = vtk_file
     ds = yt.load(file["path"], geometry=file["geometry"], unit_system="code")
-    if YT_VERSION <= Version("4.1.dev0"):
-        if ds.geometry == "spherical":
-            normal = "phi"
-        else:
-            normal = "z"
-        yt.SlicePlot(ds, normal=normal, fields=("gas", "density"))
-    else:
-        # this should work but it's broken with yt 4.0.x
-        # it is fixed in https://github.com/yt-project/yt/pull/3489
-        yt.SlicePlot(ds, normal=(0, 0, 1), fields=("gas", "density"))
+    yt.SlicePlot(ds, normal=(0, 0, 1), fields=("gas", "density"))
 
 
 def test_load_magic(vtk_file):


### PR DESCRIPTION
to undraft: need to validate a minimal working version (4.0.2, 4.0.3, 4.0.4 ?) and make it a `>=` again