### PR TITLE
MNT: drop broken toml formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,5 +58,3 @@ repos:
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
-  - id: pretty-format-toml
-    args: [--autofix]


### PR DESCRIPTION
for context: https://github.com/macisamuele/language-formatters-pre-commit-hooks/issues/133

I don't value this formatter enough to wait for it to be fixed