### PR TITLE
fix setting code units in PlutoDataset

### DIFF
--- a/tests/data/pluto_rotor/meta.yaml
+++ b/tests/data/pluto_rotor/meta.yaml
@@ -7,9 +7,9 @@ attrs:
   kind: pluto
   has_units: false
   units:
-    length: 1.0 cm
-    velocity: 1.0 cm/s
-    density: 1.0 g/cm**3
-    mass: 1.0 g
-    time: 1.0 s
-    magnetic: 3.544907701811 G
+    length: 1.49597892e+13 cm
+    velocity: 1e5 cm/s
+    density: 1.67262171e-24 g/cm**3
+    mass: 5.59982108e+15 g
+    time: 1.49597892e+08 s
+    magnetic: 4.58462477e-07 G

--- a/tests/data/pluto_sod/meta.yaml
+++ b/tests/data/pluto_sod/meta.yaml
@@ -8,9 +8,9 @@ attrs:
   current_time:
   has_units: false
   units:
-    length: 1.0 cm
-    velocity: 1.0 cm/s
-    density: 1.0 g/cm**3
-    mass: 1.0 g
-    time: 1.0 s
-    magnetic: 3.5449077 G
+    length: 1.49597892e+13 cm
+    velocity: 1e5 cm/s
+    density: 1.67262171e-24 g/cm**3
+    mass: 5.59982108e+15 g
+    time: 1.49597892e+08 s
+    magnetic: 4.58462477e-07 G

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -591,12 +591,14 @@ class PlutoVtkDataset(IdefixVtkDataset):
                 unit = unit_match.group(1).lower() + "_unit"
                 expr = unit_match.group(2)
                 # Before evaluating the expression, replace the input parameters,
-                # pre-defined constants, code units and sqrt function
+                # pre-defined constants, code units and arithmetic operators
                 # that cannot be resolved. The order doesn't matter.
                 expr = re.sub(r"g_inputParam\[(\w+)\]", self._get_input_parameter, expr)
                 expr = re.sub(r"CONST_\w+", self._get_constants, expr)
                 expr = re.sub(r"UNIT_(\w+)", self._get_unit, expr)
                 expr = re.sub(r"sqrt", "np.sqrt", expr)
+                expr = re.sub(r"log", "np.log", expr)
+                expr = re.sub(r"log10", "np.log10", expr)
                 self.parameters["definitions"][unit] = eval(expr)
 
     def _get_input_parameter(self, match: re.Match) -> str:

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -623,12 +623,19 @@ class PlutoVtkDataset(IdefixVtkDataset):
 
         # Default values of Pluto's base units which are stored in self.parameters
         # if they can be read from definitions.h
-        # Otherwise, they are set to unity in cgs.
+        # Otherwise, they are set to the default values adopted in Pluto.
+        # velocity_unit = km/s
+        # density_unit = mp/cm**3
+        # length_unit = au
         defs = self.parameters["definitions"]
         pluto_units = {
-            "velocity_unit": self.quan(defs.get("velocity_unit", 1.0), "cm/s"),
-            "density_unit": self.quan(defs.get("density_unit", 1.0), "g/cm**3"),
-            "length_unit": self.quan(defs.get("length_unit", 1.0), "cm"),
+            "velocity_unit": self.quan(defs.get("velocity_unit", 1.0e5), "cm/s"),
+            "density_unit": self.quan(
+                defs.get("density_unit", pluto_def_constants["CONST_mp"]), "g/cm**3"
+            ),
+            "length_unit": self.quan(
+                defs.get("length_unit", pluto_def_constants["CONST_au"]), "cm"
+            ),
         }
 
         uo_size = len(self.units_override)


### PR DESCRIPTION
Reminded by the discussion with @dutta-alankar in #202, some bugs need to be fixed.

- [x] adopt the correct default code unit values in Pluto
- [x] add the parsers for `log` and `log10` in unit definitions