### PR TITLE
BLD: require inifix>=4.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "inifix>=2.3.0",
+    "inifix>=4.1.0",
     "numpy>=1.17.3",
     "yt>=4.1.0",
 ]


### PR DESCRIPTION
I found this more resilient version of inifix is necessary to support some of #209