### PR TITLE
RFC: use Dataset.filename attribute instead of Dataset.parameter_filename (historic alias)

### DIFF
--- a/yt_idefix/io.py
+++ b/yt_idefix/io.py
@@ -14,7 +14,7 @@ class SingleGridIO(BaseIOHandler, ABC):
     def __init__(self, ds):
         BaseIOHandler.__init__(self, ds)
         self.ds = ds
-        self._data_file = ds.parameter_filename
+        self._data_file = ds.filename
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         data = {}


### PR DESCRIPTION
This migration is possible now that yt>=4.1 is required