### PR TITLE
cleanup: remove redundant stream position reset

### DIFF
--- a/yt_idefix/_io/vtk_io.py
+++ b/yt_idefix/_io/vtk_io.py
@@ -130,7 +130,6 @@ def read_grid_coordinates(
 ) -> Coordinates:
     # Return cell edges coordinates
 
-    fh.seek(0)
     md = read_metadata(fh)
 
     geometry = md.get("geometry", geometry)


### PR DESCRIPTION
Since the stream position was reset in `read_metadata()`, we don't need to reset it again before calling the function.