### PR TITLE
BUG: do not normalise field names to upper case in Idefix vtk

### DIFF
--- a/yt_idefix/_io/vtk_io.py
+++ b/yt_idefix/_io/vtk_io.py
@@ -204,7 +204,9 @@ def read_grid_coordinates(
     return Coordinates(coords[0], coords[1], coords[2], array_shape)
 
 
-def read_field_offset_index(fh: BinaryIO, shape: Shape, upper_case_varnames:bool) -> dict[str, int]:
+def read_field_offset_index(
+    fh: BinaryIO, shape: Shape, upper_case_varnames: bool
+) -> dict[str, int]:
     # assuming fh is correctly positioned (read_grid_coordinates must be called first)
     retv: dict[str, int] = {}
 

--- a/yt_idefix/_io/vtk_io.py
+++ b/yt_idefix/_io/vtk_io.py
@@ -205,7 +205,7 @@ def read_grid_coordinates(
 
 
 def read_field_offset_index(
-    fh: BinaryIO, shape: Shape, upper_case_varnames: bool
+    fh: BinaryIO, shape: Shape, *, upper_case_varnames: bool
 ) -> dict[str, int]:
     # assuming fh is correctly positioned (read_grid_coordinates must be called first)
     retv: dict[str, int] = {}

--- a/yt_idefix/_io/vtk_io.py
+++ b/yt_idefix/_io/vtk_io.py
@@ -204,7 +204,7 @@ def read_grid_coordinates(
     return Coordinates(coords[0], coords[1], coords[2], array_shape)
 
 
-def read_field_offset_index(fh: BinaryIO, shape: Shape) -> dict[str, int]:
+def read_field_offset_index(fh: BinaryIO, shape: Shape, upper_case_varnames:bool) -> dict[str, int]:
     # assuming fh is correctly positioned (read_grid_coordinates must be called first)
     retv: dict[str, int] = {}
 
@@ -218,7 +218,8 @@ def read_field_offset_index(fh: BinaryIO, shape: Shape) -> dict[str, int]:
         # some versions of Pluto define field names in lower case
         # so we normalize to upper case to avoid duplicating data
         # in IdefixVtkFieldInfo.known_other_fields
-        varname = varname.upper()
+        if upper_case_varnames:
+            varname = varname.upper()
 
         if datatype == "SCALARS":
             next(fh)

--- a/yt_idefix/_io/vtk_io.py
+++ b/yt_idefix/_io/vtk_io.py
@@ -217,9 +217,6 @@ def read_field_offset_index(
         s = line.decode()
         datatype, varname, dtype = s.split()
 
-        # some versions of Pluto define field names in lower case
-        # so we normalize to upper case to avoid duplicating data
-        # in IdefixVtkFieldInfo.known_other_fields
         if upper_case_varnames:
             varname = varname.upper()
 

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -738,7 +738,6 @@ class VtkMixin(Dataset):
         # parse the grid
         with open(self.filename, "rb") as fh:
             coords = vtk_io.read_grid_coordinates(fh, geometry=self.geometry)
-            "ld"
             self._field_offset_index = vtk_io.read_field_offset_index(
                 fh, coords.array_shape, upper_case_varnames
             )

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -725,11 +725,22 @@ class VtkMixin(Dataset):
         super()._parse_parameter_file()
         # from here self.geometry is assumed to be set
 
+        if self.dataset_type == "idefix-vtk":
+            # idefix may have upper and lower case
+            # characters in the variable names
+            upper_case_varnames = False
+        else:
+            # For Pluto it depends on the version
+            # for normalisation purposes they are
+            # we use upper case names
+            upper_case_varnames = True
+
         # parse the grid
         with open(self.filename, "rb") as fh:
             coords = vtk_io.read_grid_coordinates(fh, geometry=self.geometry)
+            "ld"
             self._field_offset_index = vtk_io.read_field_offset_index(
-                fh, coords.array_shape
+                fh, coords.array_shape, upper_case_varnames
             )
         self._detected_field_list = list(self._field_offset_index.keys())
 

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -725,15 +725,10 @@ class VtkMixin(Dataset):
         super()._parse_parameter_file()
         # from here self.geometry is assumed to be set
 
-        if self.dataset_type == "idefix-vtk":
-            # idefix may have upper and lower case
-            # characters in the variable names
-            upper_case_varnames = False
-        else:
-            # For Pluto it depends on the version
-            # for normalisation purposes they are
-            # we use upper case names
-            upper_case_varnames = True
+        # some versions of Pluto define field names in lower case
+        # so we normalize to upper case to avoid duplicating data
+        # in IdefixVtkFieldInfo.known_other_fields
+        normalize_varnames = self.dataset_type == "pluto-vtk"
 
         # parse the grid
         with open(self.filename, "rb") as fh:

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -739,7 +739,7 @@ class VtkMixin(Dataset):
         with open(self.filename, "rb") as fh:
             coords = vtk_io.read_grid_coordinates(fh, geometry=self.geometry)
             self._field_offset_index = vtk_io.read_field_offset_index(
-                fh, coords.array_shape, upper_case_varnames
+                fh, coords.array_shape, upper_case_varnames=normalize_varnames
             )
         self._detected_field_list = list(self._field_offset_index.keys())
 

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -727,7 +727,7 @@ class VtkMixin(Dataset):
 
         # some versions of Pluto define field names in lower case
         # so we normalize to upper case to avoid duplicating data
-        # in IdefixVtkFieldInfo.known_other_fields
+        # in BaseVtkFields.known_other_fields
         normalize_varnames = self.dataset_type == "pluto-vtk"
 
         # parse the grid


### PR DESCRIPTION
Idefix allows the user to output custom fields in the vtk files and their name is chosen by the user. This means that names containing lower case character may be chosen by the user. Moreover the default vector potential field name also contains a lower case character (_e.g._ `AX1e`)
Currently, for normalisation reasons with different Pluto versions, all native field names are converted to upper case.
This means that such fields can't be accessed via _e.g._ `("idefix-vtk","AX1e")`.

This PR proposes to use this normalisation for Pluto datasets only. This allows the fields to be accessed with the same name they have in the vtk file.