### PR TITLE
UX: rephrase a warning

### DIFF
--- a/tests/test_vtk.py
+++ b/tests/test_vtk.py
@@ -107,9 +107,7 @@ def test_missing_inifile(tmp_path):
         tmpdir,
         ignore=shutil.ignore_patterns("*.ini"),
     )
-    with pytest.warns(
-        UserWarning, match=r"The inifile is missing for unit definitions."
-    ):
+    with pytest.warns(UserWarning, match="Could not find inifile"):
         yt.load(tmpdir / "data.0010.vtk")
 
 

--- a/yt_idefix/data_structures.py
+++ b/yt_idefix/data_structures.py
@@ -662,11 +662,13 @@ class StaticPlutoDataset(GoodboyDataset, ABC):
         """Replace matched input parameters with its value"""
         key = match.group(1)
         if key not in self.parameters.get("Parameters", {}):
-            if not self._inifile:
+            if not os.path.exists(self._inifile):
                 warnings.warn(
-                    "The inifile is missing for unit definitions. "
-                    f"Specify it to the keyword argument 'inifile' (default: {self._default_inifile}), "
-                    "or make sure that all fields are in code units!",
+                    f"Could not find inifile ({self._inifile}). "
+                    "Inferred code units might be inaccurate\n"
+                    "To silence this warning, specify the inifile keyword argument to yt.load, "
+                    "as a path (either absolute or relative to the data file's parent directory). "
+                    f"Default is {self._default_inifile!r}. ",
                     stacklevel=2,
                 )
             else:


### PR DESCRIPTION
follow up to #245

I would also like to do something about the second warning because it's a problem that it's not possible to silence it.
I'm thinking we should probably just raise a hard error is receiving an invalid `pluto.ini` file, but is it actually invalid to leave units out of it ?

ping @xshaokun for review