### PR TITLE
TST: use numpy and matplotlib nightlies in bleeding-edge CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -40,6 +40,8 @@ jobs:
     - name: Build
       run: |
         python -m pip install --upgrade pip
+        python -m pip install --pre --extra-index \
+          https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy matplotlib
         python -m pip install git+https://github.com/yt-project/yt.git
         python -m pip install .
         python -m pip install --requirement requirements/tests.txt


### PR DESCRIPTION
Looks like we're only now catching up on deprecation warnings from numpy 1.25, next time I'd like to see them before the release.