### PR TITLE
MNT: swap order for ruff pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,9 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.3.0
   hooks:
+  - id: ruff-format
   - id: ruff
     args: [--fix]
-  - id: ruff-format
 
 - repo: https://github.com/neutrinoceros/inifix.git
   rev: v4.4.2


### PR DESCRIPTION
Formatting first, linting second generates less noise.