### PR TITLE
TST: bump uv (0.2.25 -> 0.4.1)

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: yezz123/setup-uv@v4
       with:
-        uv-version: 0.2.25
+        uv-version: 0.4.1
         uv-venv: .venv
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - uses: yezz123/setup-uv@v4
       with:
-        uv-version: 0.2.25
+        uv-version: 0.4.1
         uv-venv: .venv
 
     - if: matrix.deps == 'minimal'
@@ -78,7 +78,7 @@ jobs:
 
     - uses: yezz123/setup-uv@v4
       with:
-        uv-version: 0.2.25
+        uv-version: 0.4.1
         uv-venv: .venv
 
     - name: Build


### PR DESCRIPTION
Newer versions log which dependencies were built, which is particularily useful in bleeding-edge CI