### PR TITLE
BUG: fix native coordinate parsing for azimuthal-normal spherical slices

### DIFF
--- a/src/yt_idefix/_io/commons.py
+++ b/src/yt_idefix/_io/commons.py
@@ -68,12 +68,12 @@ def get_native_coordinates_from_cartesian(
     elif geometry == "spherical":
         # Reconstruct the spherical coordinate system
         if shape.n3 == 1:
-            r = np.sqrt(xcart[:, 0, 0] ** 2 + ycart[:, 0, 0] ** 2)
+            r = np.sqrt(xcart[:, 0, 0] ** 2 + zcart[:, 0, 0] ** 2)
             phi = np.unwrap(
-                np.arctan2(zcart[0, shape.n2 // 2, :], xcart[0, shape.n2 // 2, :])
+                np.arctan2(ycart[0, shape.n2 // 2, :], xcart[0, shape.n2 // 2, :])
             )
             theta = np.arccos(
-                ycart[0, :, 0] / np.sqrt(xcart[0, :, 0] ** 2 + ycart[0, :, 0] ** 2)
+                zcart[0, :, 0] / np.sqrt(xcart[0, :, 0] ** 2 + zcart[0, :, 0] ** 2)
             )
         else:
             r = np.sqrt(xcart[:, 0, 0] ** 2 + ycart[:, 0, 0] ** 2 + zcart[:, 0, 0] ** 2)


### PR DESCRIPTION
This patch directly mimicks upstream fixes, so I'm not going to add a test for it here.
