### PR TITLE
TST: add CPython 3.13 to regular CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         - ubuntu-latest
         python-version:
         - '3.10'
-        - '3.12'
+        - '3.13'
         install-args:
         - ''
         - --extra HDF5


### PR DESCRIPTION
blocked by yt 4.4.0 (first expected release with cp313 wheels)