### PR TITLE
TST: update uv configuration in bleeding-edge CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -39,7 +39,8 @@ jobs:
         echo "UV_PYTHON_PREFERENCE=only-system" >> $GITHUB_ENV
         echo "UV_PYTHON=3.13" >> $GITHUB_ENV
         echo "UV_PRERELEASE=allow" >> $GITHUB_ENV
-        echo "UV_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" >> $GITHUB_ENV
+        echo "UV_INDEX=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" >> $GITHUB_ENV
+        echo "UV_INDEX_STRATEGY=unsafe-best-match" >> $GITHUB_ENV
 
     - name: Build
       run: |


### PR DESCRIPTION
[example logs](https://github.com/neutrinoceros/yt_idefix/actions/runs/12663389605)
[last succesful run](https://github.com/neutrinoceros/yt_idefix/actions/runs/12637357746/job/35211369047)

the only difference I know of at the moment is that uv was implicitly upgraded from 0.5.14 to 0.5.15, so I'm trying to pin it back to 0.5.14