### PR TITLE
BUG: fix reading native grid coordinates for idefix 2.2 vtk files

### DIFF
--- a/src/yt_idefix/_io/vtk_io.py
+++ b/src/yt_idefix/_io/vtk_io.py
@@ -234,9 +234,9 @@ def read_grid_coordinates(
     if "native_coordinates" in md:
         nc = md["native_coordinates"]
         return Coordinates(
-            nc["X1C_NATIVE_COORDINATES"],
-            nc["X2C_NATIVE_COORDINATES"],
-            nc["X3C_NATIVE_COORDINATES"],
+            nc["X1L_NATIVE_COORDINATES"],
+            nc["X2L_NATIVE_COORDINATES"],
+            nc["X3L_NATIVE_COORDINATES"],
             array_shape,
         )
     else:


### PR DESCRIPTION
Fix `read_grid_coordinates()` method so that it returns cell edges when native coordinates are in the metadata.