### PR TITLE
DEP: drop support for CPython 3.10.0, 3.10.1 and 3.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 keywords = [
     "astronomy astrophysics visualization amr adaptivemeshrefinement",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10.3"
 dependencies = [
     "inifix>=4.1.0",
     "numpy>=1.21.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1,19 +1,9 @@
 version = 1
 revision = 1
-requires-python = ">=3.10"
+requires-python = ">=3.10.3"
 resolution-markers = [
-    "python_full_version >= '3.10.3' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.10.3' and platform_machine != 'arm64') or (python_full_version >= '3.10.3' and sys_platform != 'darwin')",
-    "python_full_version < '3.10.3'",
-]
-
-[[package]]
-name = "asttokens"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918 },
+    "platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "platform_machine != 'arm64' or sys_platform != 'darwin'",
 ]
 
 [[package]]
@@ -36,18 +26,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
-]
-
-[[package]]
-name = "comm"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "traitlets", marker = "python_full_version < '3.10.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/a8/fb783cb0abe2b5fded9f55e5703015cdf1c9c85b3669087c538dd15a6a86/comm-0.2.2.tar.gz", hash = "sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e", size = 6210 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl", hash = "sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3", size = 7180 },
 ]
 
 [[package]]
@@ -124,15 +102,6 @@ wheels = [
 ]
 
 [[package]]
-name = "decorator"
-version = "5.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190 },
-]
-
-[[package]]
 name = "ewah-bool-utils"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -170,15 +139,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453 },
-]
-
-[[package]]
-name = "executing"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702 },
 ]
 
 [[package]]
@@ -272,65 +232,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/84/fd63f3e949a2e91fab93c588bcb559a0d8213d34f52d26d0bf77cf2b058d/inifix-6.0.1.tar.gz", hash = "sha256:dd94dddf37a514d0643bf74563abc3beb9490cba7c5853ec0259791b325bbb26", size = 38180 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/38/2dc3706e594b2d5892a18a5be83e2f6398cb0586f1b1d5594ecf25a7c526/inifix-6.0.1-py3-none-any.whl", hash = "sha256:aaf98321182a3bb65beb43f0078f3de1f782f41eae8ed9bfa3230f7a46eb955e", size = 28475 },
-]
-
-[[package]]
-name = "ipython"
-version = "8.34.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10.3' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.10.3'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10.3'" },
-    { name = "jedi", marker = "python_full_version < '3.10.3'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.10.3'" },
-    { name = "pexpect", marker = "python_full_version < '3.10.3' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.10.3'" },
-    { name = "pygments", marker = "python_full_version < '3.10.3'" },
-    { name = "stack-data", marker = "python_full_version < '3.10.3'" },
-    { name = "traitlets", marker = "python_full_version < '3.10.3'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/13/18/1a60aa62e9d272fcd7e658a89e1c148da10e1a5d38edcbcd834b52ca7492/ipython-8.34.0.tar.gz", hash = "sha256:c31d658e754673ecc6514583e7dda8069e47136eb62458816b7d1e6625948b5a", size = 5508477 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/78/45615356bb973904856808183ae2a5fba1f360e9d682314d79766f4b88f2/ipython-8.34.0-py3-none-any.whl", hash = "sha256:0419883fa46e0baa182c5d50ebb8d6b49df1889fdb70750ad6d8cfe678eda6e3", size = 826731 },
-]
-
-[[package]]
-name = "ipywidgets"
-version = "8.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "comm", marker = "python_full_version < '3.10.3'" },
-    { name = "ipython", marker = "python_full_version < '3.10.3'" },
-    { name = "jupyterlab-widgets", marker = "python_full_version < '3.10.3'" },
-    { name = "traitlets", marker = "python_full_version < '3.10.3'" },
-    { name = "widgetsnbextension", marker = "python_full_version < '3.10.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/4c/dab2a281b07596a5fc220d49827fe6c794c66f1493d7a74f1df0640f2cc5/ipywidgets-8.1.5.tar.gz", hash = "sha256:870e43b1a35656a80c18c9503bbf2d16802db1cb487eec6fab27d683381dde17", size = 116723 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/2d/9c0b76f2f9cc0ebede1b9371b6f317243028ed60b90705863d493bae622e/ipywidgets-8.1.5-py3-none-any.whl", hash = "sha256:3290f526f87ae6e77655555baba4f36681c555b8bdbbff430b70e52c34c86245", size = 139767 },
-]
-
-[[package]]
-name = "jedi"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "parso", marker = "python_full_version < '3.10.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278 },
-]
-
-[[package]]
-name = "jupyterlab-widgets"
-version = "3.0.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/59/73/fa26bbb747a9ea4fca6b01453aa22990d52ab62dd61384f1ac0dc9d4e7ba/jupyterlab_widgets-3.0.13.tar.gz", hash = "sha256:a2966d385328c1942b683a8cd96b89b8dd82c8b8f81dda902bb2bc06d46f5bed", size = 203556 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/93/858e87edc634d628e5d752ba944c2833133a28fa87bb093e6832ced36a3e/jupyterlab_widgets-3.0.13-py3-none-any.whl", hash = "sha256:e3cda2c233ce144192f1e29914ad522b2f4c40e77214b0cc97377ca3d323db54", size = 214392 },
 ]
 
 [[package]]
@@ -473,18 +374,6 @@ wheels = [
 ]
 
 [[package]]
-name = "matplotlib-inline"
-version = "0.1.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "traitlets", marker = "python_full_version < '3.10.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90", size = 8159 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca", size = 9899 },
-]
-
-[[package]]
 name = "more-itertools"
 version = "10.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -621,27 +510,6 @@ wheels = [
 ]
 
 [[package]]
-name = "parso"
-version = "0.8.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650 },
-]
-
-[[package]]
-name = "pexpect"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ptyprocess", marker = "python_full_version < '3.10.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772 },
-]
-
-[[package]]
 name = "pillow"
 version = "11.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -718,36 +586,6 @@ wheels = [
 ]
 
 [[package]]
-name = "prompt-toolkit"
-version = "3.0.50"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth", marker = "python_full_version < '3.10.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/e1/bd15cb8ffdcfeeb2bdc215de3c3cffca11408d829e4b8416dcfe71ba8854/prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab", size = 429087 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/ea/d836f008d33151c7a1f62caf3d8dd782e4d15f6a43897f64480c2b8de2ad/prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198", size = 387816 },
-]
-
-[[package]]
-name = "ptyprocess"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993 },
-]
-
-[[package]]
-name = "pure-eval"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842 },
-]
-
-[[package]]
 name = "pyaml"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -757,15 +595,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/06/04b9c1907c13dc81729a9c6b4f42eab47baab7a8738ed5d2683eac215ad0/pyaml-25.1.0.tar.gz", hash = "sha256:33a93ac49218f57e020b81e280d2706cea554ac5a76445ac79add760d019c709", size = 29469 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/c1/ec1930bc6c01754b8baf3c99420f340b920561f0060bccbf81809db354cc/pyaml-25.1.0-py3-none-any.whl", hash = "sha256:f7b40629d2dae88035657c860f539db3525ddd0120a11e0bcb44d47d5968b3bc", size = 26074 },
-]
-
-[[package]]
-name = "pygments"
-version = "2.19.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]
@@ -860,20 +689,6 @@ wheels = [
 ]
 
 [[package]]
-name = "stack-data"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asttokens", marker = "python_full_version < '3.10.3'" },
-    { name = "executing", marker = "python_full_version < '3.10.3'" },
-    { name = "pure-eval", marker = "python_full_version < '3.10.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
-]
-
-[[package]]
 name = "sympy"
 version = "1.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -946,15 +761,6 @@ wheels = [
 ]
 
 [[package]]
-name = "traitlets"
-version = "5.14.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359 },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -978,82 +784,22 @@ wheels = [
 ]
 
 [[package]]
-name = "wcwidth"
-version = "0.2.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
-]
-
-[[package]]
-name = "widgetsnbextension"
-version = "4.0.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/fc/238c424fd7f4ebb25f8b1da9a934a3ad7c848286732ae04263661eb0fc03/widgetsnbextension-4.0.13.tar.gz", hash = "sha256:ffcb67bc9febd10234a362795f643927f4e0c05d9342c727b65d2384f8feacb6", size = 1164730 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/02/88b65cc394961a60c43c70517066b6b679738caf78506a5da7b88ffcb643/widgetsnbextension-4.0.13-py3-none-any.whl", hash = "sha256:74b2692e8500525cc38c2b877236ba51d34541e6385eeed5aec15a70f88a6c71", size = 2335872 },
-]
-
-[[package]]
-name = "yt"
-version = "4.3.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10.3'",
-]
-dependencies = [
-    { name = "cmyt", marker = "python_full_version < '3.10.3'" },
-    { name = "ewah-bool-utils", marker = "python_full_version < '3.10.3'" },
-    { name = "ipywidgets", marker = "python_full_version < '3.10.3'" },
-    { name = "matplotlib", marker = "python_full_version < '3.10.3'" },
-    { name = "more-itertools", marker = "python_full_version < '3.10.3'" },
-    { name = "numpy", marker = "python_full_version < '3.10.3'" },
-    { name = "packaging", marker = "python_full_version < '3.10.3'" },
-    { name = "pillow", marker = "python_full_version < '3.10.3'" },
-    { name = "tomli", marker = "python_full_version < '3.10.3'" },
-    { name = "tomli-w", marker = "python_full_version < '3.10.3'" },
-    { name = "tqdm", marker = "python_full_version < '3.10.3'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10.3'" },
-    { name = "unyt", marker = "python_full_version < '3.10.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/c3/8e09b54c323a4bbe40159e824936bb4d65bfeb5098052b165e412c8cfbae/yt-4.3.1.tar.gz", hash = "sha256:7b6db5c336dc22dd2212bb17c3b18f42cfe144bb1f6c3dda0dcd47eb77195e0e", size = 13810591 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/a6/66992301730dd08b04778a86c33d86089ccb4bd797296ae55592741ab764/yt-4.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dfb0686dd9478e09e42d58233db59d3f412cea634d01ff5d00f97209bdde88aa", size = 16589365 },
-    { url = "https://files.pythonhosted.org/packages/0d/0b/e0f84b8f285e30f88cb40e48584ab50cfd01a2fbe1f2ddffe1827813773d/yt-4.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e120feed11a591fb1916ebac9bcf6b9b4ee3554cbb1b18e51c9a8fd4c723b824", size = 16099914 },
-    { url = "https://files.pythonhosted.org/packages/dc/b0/a58f1c70152091b16adb037606ac0c5f6cc11062b996443bdd2943a8c44e/yt-4.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2571f46fd8a7f011dd8572cad9159ff27f528bb4bbd3334f056d77f3ab7a67", size = 44385017 },
-    { url = "https://files.pythonhosted.org/packages/48/a0/6df19f31fc375fb5a45ff1fc866231e574b9b1b080f1cf02f56dca141090/yt-4.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:3ec46db9d003f33363501309a6299854fa657b2f9996f206c012635a3717d363", size = 15717109 },
-    { url = "https://files.pythonhosted.org/packages/c7/b6/9cdf49f84777c0981ad6ff35d83846b5c66ed0b7c07e77fe3c47c474f92b/yt-4.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a0f5eedb4e671c9788d33713b0adafb3df833c99c11d56c022a7663c83ec0d15", size = 16597292 },
-    { url = "https://files.pythonhosted.org/packages/45/c8/7c6ef45aebfcbb1ad05249f802f46001928c8c333af38d68b8a6599fccec/yt-4.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:682a9f930f057907e944425ba80276d35babce2645ce0a75889e2e905c84b1ca", size = 16107694 },
-    { url = "https://files.pythonhosted.org/packages/fb/d5/6b58fdc4161fea76e049cd23e82fd47c9047beb66769616301c6563cb353/yt-4.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ed1548aad8c3d73abe06cbb03e7ba800082894f27f43a4683cc58a4ff25a742", size = 46670950 },
-    { url = "https://files.pythonhosted.org/packages/f8/df/082f97137ea356d2c8804cf05645d87c1b4b7a3bab3698699da4debffdf9/yt-4.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:f74b520e03e65cc96a05037f32b4dc8cc4d5e5348ef6f88cafb2cc89f86636d9", size = 15731536 },
-    { url = "https://files.pythonhosted.org/packages/df/45/ab3e438ea6a29dcc6661bbd608f8b790d8c098f30c4a809bf5372b45709c/yt-4.3.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:12d720d3cc935c6041030f76eed871554232211b1907be357be23b85c207f28b", size = 16585669 },
-    { url = "https://files.pythonhosted.org/packages/a9/ae/01354c513dbcfe9516b665875d69f2c486901dade0c649126268f873a465/yt-4.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4472f2e5904cb1d95a816c0dbe0a3d5231e8ed79a19dcf60be13040ca39b7220", size = 16127804 },
-    { url = "https://files.pythonhosted.org/packages/bf/a0/8990a88031942c377b8ec0ca64426babdc9d6b25f3e580cae409097d2c2a/yt-4.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9692c48a932024e78cbeb303265331b824476015fddd1ed7360d9f8fadafa384", size = 46376673 },
-    { url = "https://files.pythonhosted.org/packages/5f/ed/2588403f764ca7a687080d1413c895a0873fabd4099578d19b63389a97f6/yt-4.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:e9dea6fc405ef2d494bf240d2332f31d804fee95bb66bca1e6bc8fedb07863ee", size = 15735118 },
-]
-
-[[package]]
 name = "yt"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10.3' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.10.3' and platform_machine != 'arm64') or (python_full_version >= '3.10.3' and sys_platform != 'darwin')",
-]
 dependencies = [
-    { name = "cmyt", marker = "python_full_version >= '3.10.3'" },
-    { name = "ewah-bool-utils", marker = "python_full_version >= '3.10.3'" },
-    { name = "matplotlib", marker = "python_full_version >= '3.10.3'" },
-    { name = "more-itertools", marker = "python_full_version >= '3.10.3'" },
-    { name = "numpy", marker = "python_full_version >= '3.10.3'" },
-    { name = "packaging", marker = "python_full_version >= '3.10.3'" },
-    { name = "pillow", marker = "python_full_version >= '3.10.3'" },
-    { name = "tomli", marker = "python_full_version >= '3.10.3' and python_full_version < '3.11'" },
-    { name = "tomli-w", marker = "python_full_version >= '3.10.3'" },
-    { name = "tqdm", marker = "python_full_version >= '3.10.3'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10.3' and python_full_version < '3.12'" },
-    { name = "unyt", marker = "python_full_version >= '3.10.3'" },
+    { name = "cmyt" },
+    { name = "ewah-bool-utils" },
+    { name = "matplotlib" },
+    { name = "more-itertools" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli-w" },
+    { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "unyt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/3d/83c89a1afb13b7baff5769b572a36528ce4b8aa047215a73412a3a57f74b/yt-4.4.0.tar.gz", hash = "sha256:0e15df9cb21abe582f8128bf0705a3bc0f4805f97efd6b4f883073703941c0d5", size = 4941964 }
 wheels = [
@@ -1087,8 +833,7 @@ dependencies = [
     { name = "inifix" },
     { name = "numpy" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-    { name = "yt", version = "4.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10.3'" },
-    { name = "yt", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10.3'" },
+    { name = "yt" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
This follows yt 4.4.0 and allows for quite significant simplifications in my lock file

```
Removed asttokens v3.0.0
Removed comm v0.2.2
Removed decorator v5.2.1
Removed executing v2.2.0
Removed ipython v8.34.0
Removed ipywidgets v8.1.5
Removed jedi v0.19.2
Removed jupyterlab-widgets v3.0.13
Removed matplotlib-inline v0.1.7
Removed parso v0.8.4
Removed pexpect v4.9.0
Removed prompt-toolkit v3.0.50
Removed ptyprocess v0.7.0
Removed pure-eval v0.2.3
Removed pygments v2.19.1
Removed stack-data v0.6.3
Removed traitlets v5.14.3
Removed wcwidth v0.2.13
Removed widgetsnbextension v4.0.13
Updated yt v4.3.1, v4.4.0 -> v4.4.0
```